### PR TITLE
Changed structure for easier use

### DIFF
--- a/Garhal/communication.c
+++ b/Garhal/communication.c
@@ -23,11 +23,14 @@ NTSTATUS IoControl(PDEVICE_OBJECT DeviceObject, PIRP Irp)
 		PKERNEL_READ_REQUEST ReadOutput = (PKERNEL_READ_REQUEST)Irp->AssociatedIrp.SystemBuffer;
 
 		PEPROCESS Process;
-		// Get our process
-		if (NT_SUCCESS(PsLookupProcessByProcessId(ReadInput->ProcessId, &Process)))
-			KeReadVirtualMemory(Process, ReadInput->Address,
-				&ReadInput->Response, ReadInput->Size);
 
+		// Get our process
+		if (NT_SUCCESS(PsLookupProcessByProcessId(ReadInput->ProcessId, &Process))) {
+
+			//read from ReadInput->Address and write it to pBuff so we can use the data in our controller
+			KeReadVirtualMemory(Process, ReadInput->Address, ReadInput->pBuff, ReadInput->Size);
+		}
+			
 		//DbgPrintEx(0, 0, "Read Params:  %lu, %#010x \n", ReadInput->ProcessId, ReadInput->Address);
 		//DbgPrintEx(0, 0, "Value: %lu \n", ReadOutput->Response);
 
@@ -41,10 +44,11 @@ NTSTATUS IoControl(PDEVICE_OBJECT DeviceObject, PIRP Irp)
 
 		PEPROCESS Process;
 		// Get our process
-		if (NT_SUCCESS(PsLookupProcessByProcessId(WriteInput->ProcessId, &Process)))
-			KeWriteVirtualMemory(Process, &WriteInput->Value,
-				WriteInput->Address, WriteInput->Size);
-
+		if (NT_SUCCESS(PsLookupProcessByProcessId(WriteInput->ProcessId, &Process))) {
+			// copy the value of pBuff to WriteInput->Address
+			KeWriteVirtualMemory(Process, WriteInput->pBuff, WriteInput->Address, WriteInput->Size);
+		}
+			
 		//DbgPrintEx(0, 0, "Write Params:  %lu, %#010x \n", WriteInput->Value, WriteInput->Address);
 
 		Status = STATUS_SUCCESS;

--- a/Garhal/communication.h
+++ b/Garhal/communication.h
@@ -25,7 +25,7 @@ typedef struct _KERNEL_READ_REQUEST
 	ULONG ProcessId;
 
 	ULONG Address;
-	ULONG Response;
+	PVOID pBuff;
 	ULONG Size;
 
 } KERNEL_READ_REQUEST, * PKERNEL_READ_REQUEST;
@@ -35,7 +35,7 @@ typedef struct _KERNEL_WRITE_REQUEST
 	ULONG ProcessId;
 
 	ULONG Address;
-	ULONG Value;
+	PVOID pBuff;
 	ULONG Size;
 
 } KERNEL_WRITE_REQUEST, * PKERNEL_WRITE_REQUEST;

--- a/GarhalController/communications.h
+++ b/GarhalController/communications.h
@@ -22,7 +22,7 @@ typedef struct _KERNEL_READ_REQUEST
 	ULONG ProcessId;
 
 	ULONG Address;
-	ULONG Response;
+	PVOID pBuff;
 	ULONG Size;
 
 } KERNEL_READ_REQUEST, * PKERNEL_READ_REQUEST;
@@ -32,7 +32,7 @@ typedef struct _KERNEL_WRITE_REQUEST
 	ULONG ProcessId;
 
 	ULONG Address;
-	ULONG Value;
+	PVOID pBuff;
 	ULONG Size;
 
 } KERNEL_WRITE_REQUEST, * PKERNEL_WRITE_REQUEST;


### PR DESCRIPTION
With this change, we can read & write structs like DXD9VECTOR3 that has a much bigger size than ULONG, thus we won't need to write every value in HEX and write structs which will allow us to make less wpm calls and maintain performance.