### PR TITLE
Fix #93 issue

### DIFF
--- a/Garhal/garhal.c
+++ b/Garhal/garhal.c
@@ -69,6 +69,11 @@ NTSTATUS DriverEntry(PDRIVER_OBJECT pDriverObject, PUNICODE_STRING pRegistryPath
 	pDeviceObject->Flags |= DO_DIRECT_IO;
 	pDeviceObject->Flags &= ~DO_DEVICE_INITIALIZING;
 
+	// 4B4DB4B3: Bypass MmVerifyRegisterCallbacksFlags
+	// Fix STATUS_ACCESS_DENIED
+	PKLDR_DATA_TABLE_ENTRY ldr = (PKLDR_DATA_TABLE_ENTRY)pDriverObject->DriverSection;
+	ldr->Flags |= 0x20; // LDRP_VALID_SECTION
+
 	NTSTATUS reg = RegisterOBCallback();
 	if (reg == STATUS_SUCCESS)
 	{

--- a/Garhal/gstructs.h
+++ b/Garhal/gstructs.h
@@ -3,6 +3,28 @@
 #include <ntifs.h>
 #include <minwindef.h>
 
+// 4b4db4b3
+typedef struct _KLDR_DATA_TABLE_ENTRY {
+	LIST_ENTRY InLoadOrderLinks;
+	PVOID ExceptionTable;
+	ULONG ExceptionTableSize;
+	PVOID GpValue;
+	PVOID NonPagedDebugInfo;
+	PVOID DllBase;
+	PVOID EntryPoint;
+	ULONG SizeOfImage;
+	UNICODE_STRING FullDllName;
+	UNICODE_STRING BaseDllName;
+	ULONG Flags;
+	USHORT LoadCount;
+	USHORT __Unused5;
+	PVOID SectionPointer;
+	ULONG CheckSum;
+	PVOID LoadedImports;
+	PVOID PatchInformation;
+} KLDR_DATA_TABLE_ENTRY, * PKLDR_DATA_TABLE_ENTRY;
+// 4b4db4b3
+
 typedef struct _LDR_DATA_TABLE_ENTRY
 {
 	LIST_ENTRY InLoadOrderLinks;


### PR DESCRIPTION
Solving an error where ObRegisterCallbacks returned STATUS_ACCESS_DENIED due to checking driver flags inside the kernel