### PR TITLE
Fixed Aimbot::getSensitivity() - corrected sens convar deobfuscate

### DIFF
--- a/GarhalController/Aimbot.cpp
+++ b/GarhalController/Aimbot.cpp
@@ -195,7 +195,7 @@ Vector3 Aimbot::getViewAngles()
 
 float Aimbot::getSensitivity()
 {
-    uint32_t sensitivityPtr = Driver.ReadVirtualMemory<uint32_t>(ProcessId, ClientAddress + hazedumper::signatures::dwSensitivityPtr, sizeof(uint32_t));
+    uint32_t sensitivityPtr = ClientAddress + hazedumper::signatures::dwSensitivityPtr;
     uint32_t sensitivity = Driver.ReadVirtualMemory<uint32_t>(ProcessId, ClientAddress + hazedumper::signatures::dwSensitivity, sizeof(uint32_t));
 
     sensitivity ^= sensitivityPtr;

--- a/GarhalController/Aimbot.cpp
+++ b/GarhalController/Aimbot.cpp
@@ -226,7 +226,7 @@ void Aimbot::setViewAngles(Vector3& viewAngles)
 
 void Aimbot::setSensitivity(float sens)
 {
-    uint32_t sensitivityPtr = Driver.ReadVirtualMemory<uint32_t>(ProcessId, ClientAddress + hazedumper::signatures::dwSensitivityPtr, sizeof(uint32_t));
+    uint32_t sensitivityPtr = ClientAddress + hazedumper::signatures::dwSensitivityPtr;
     uint32_t sensitivity = *reinterpret_cast<uint32_t*>(&sens) ^ sensitivityPtr;
 
     Driver.WriteVirtualMemory(ProcessId, ClientAddress + hazedumper::signatures::dwSensitivity, sensitivity, sizeof(sensitivity));


### PR DESCRIPTION
Fixed Sens Convar

In-Game Sens:
![game_sens](https://user-images.githubusercontent.com/16841301/148212756-0a608f41-a13c-445f-88b9-6e4a1376badf.png)

Earilier:
```cpp
uint32_t sensitivityPtr = Driver.ReadVirtualMemory<uint32_t>(ProcessId, ClientAddress + hazedumper::signatures::dwSensitivityPtr, sizeof(uint32_t));

uint32_t sensitivity = Driver.ReadVirtualMemory<uint32_t>(ProcessId, ClientAddress + hazedumper::signatures::dwSensitivity, sizeof(uint32_t));

sensitivity ^= sensitivityPtr;
```
![before](https://user-images.githubusercontent.com/16841301/148212883-370e1260-4087-447c-b9e8-d735f97d4ecd.PNG)

After Fix:
```cpp
uint32_t sensitivityPtr = ClientAddress + hazedumper::signatures::dwSensitivityPtr;

uint32_t sensitivity = Driver.ReadVirtualMemory<uint32_t>(ProcessId, ClientAddress + hazedumper::signatures::dwSensitivity, sizeof(uint32_t));

sensitivity ^= sensitivityPtr;
```
![after](https://user-images.githubusercontent.com/16841301/148212945-15b1fb5b-28d3-460f-aabe-f644aff7f183.PNG)
